### PR TITLE
feat: add literal rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "mocha": true,
     "node": true
   },
-  "extends": ["natura"],
+  "extends": ["@naturacosmeticos/natura"],
   "parserOptions": {
     "ecmaVersion": 2017
   },

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# vscode user config
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+cache:
+  yarn: true
+  directories:
+    - node_modules
+node_js:
+  - 10
+  - 9
+  - 8
+  - 7
+  - 6
+install:
+  - yarn
+script:
+  - yarn lint
+  - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - 10
   - 9
   - 8
-  - 7
   - 6
 install:
   - yarn

--- a/README.md
+++ b/README.md
@@ -17,9 +17,43 @@ Considering the follow scenario:
 -------header.js
 ```
 
-In your `header.js` you have a call to your `i18n` function to get the localized value of the string `logout`: `translate('logout')`.
+In your `header.js` you have a call to your `i18n` function to get the localized value of the string *logout*: `translate('logout')`
 
 The `i18n-checker` will verify if the `logout` is defined in each locale file you have.
+
+# How to use
+
+## Installation
+
+```bash
+npm i --save-dev '@naturacosmeticos/eslint-plugin-i18n-checker'
+
+yarn add -D '@naturacosmeticos/eslint-plugin-i18n-checker'
+```
+
+## Configuration
+
+In your eslintrc file you need to add `@naturacosmeticos/eslint-plugin-i18n-checker` in the `plugins` section.
+
+### Options
+
+You can configure the following options:
+
+* **localesPath** - *string* - your locales relative path (*default is `/locales/`*)
+* **messagesBasePath** - *string* - if your locales files has a base path you can pass it (*default is undefined*)
+* **translationFunctionName** - *string* - the name of your translation function (*default is `translate`*)
+
+Example:
+
+```
+"i18n-checker/path-in-locales": ['error',
+  {
+    localesPath: 'public/locales/',
+    messagesBasePath: 'translations',
+    translationFunctionName: 't'
+  }
+]
+```
 
 # Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,71 +1,18 @@
-const PathLocator = require('./src/path-locator');
-
-const runRule = (path, pathLocator, context, node) => {
-  const result = pathLocator.call(path);
-
-  if (result.error) {
-    context.report({
-      node,
-      message: result.error,
-    });
-  }
-}
-
 module.exports = {
-  meta: {
-    docs: {
-      description: 'Check if all localization strings are defined in locales folder',
-      category: 'i18n',
-      recommended: true,
-    },
-    schema: [{
-      type: 'object',
-      properties: {
-        localesPath: {
-          type: 'array',
-          items: {
-            type: 'string'
-          },
-        },
-        translationFunctionName: {
-          type: 'string'
-        },
-      },
-      required: [ 'localesPath' ],
-      additionalProperties: false
-    }]
+  rules: {
+    'path-in-locales': require('./src/path-in-locales'),
   },
-  create(context) {
-    const { options } = context;
-    let { localesPath, translationFunctionName } = options[0] || {};
-
-    translationFunctionName = translationFunctionName || 'translate';
-
-    const pathLocator = new PathLocator(localesPath);
-
-    return {
-      ExpressionStatement(node) {
-        if (node.expression.callee.name !== translationFunctionName) {
-          return;
-        }
-
-        const translateFirstArgument = node.expression.arguments[0] && node.expression.arguments[0].value;
-
-        if (translateFirstArgument) {
-          runRule(translateFirstArgument, pathLocator, context, node);
-        }
-      },
-      MemberExpression(node) {
-        if (node.object.name !== translationFunctionName) {
-          return;
-        }
-
-        const translateFirstArgument = node.parent.arguments[0] && node.parent.arguments[0].value;
-
-        if (translateFirstArgument) {
-          runRule(translateFirstArgument, pathLocator, context, node);
-        }
-      },
+  rulesConfig: {
+    'path-in-locales': 0,
+  },
+  configs: {
+    recommended: {
+      plugins: [
+        'i18n',
+      ],
+      rules: {
+        'i18n/path-in-locales': 'warn',
+      }
     }
-  },
-}
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "eslint-plugin-i18n-checker",
+  "name": "@naturacosmeticos/eslint-plugin-i18n-checker",
   "version": "1.0.0",
+  "author": "Natura Cosméticos <TDDAArquitetura@natura.net>",
   "main": "index.js",
   "description": "Helps you identify what locales keys are not included in your locales files",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^5.7.0",
-    "eslint-config-natura": "^1.0.0",
+    "@naturacosmeticos/eslint-config-natura": "^1.0.0",
     "eslint-plugin-import": "^2.14.0",
     "mocha": "^5.2.0"
   },

--- a/src/path-in-locales.js
+++ b/src/path-in-locales.js
@@ -78,10 +78,7 @@ module.exports = {
       additionalProperties: false,
       properties: {
         localesPath: {
-          items: {
-            type: 'string',
-          },
-          type: 'array',
+          type: 'string',
         },
         messagesBasePath: {
           type: 'string',
@@ -90,7 +87,6 @@ module.exports = {
           type: 'string',
         },
       },
-      required: ['localesPath'],
       type: 'object',
     }],
   },

--- a/src/path-in-locales.js
+++ b/src/path-in-locales.js
@@ -1,0 +1,97 @@
+const PathLocator = require('./path-locator');
+
+class PathInLocalesRunner {
+  constructor(context, options) {
+    const { localesPath, messagesBasePath, translationFunctionName } = options;
+
+    this.context = context;
+    this.translationFunctionName = translationFunctionName;
+    this.pathLocator = new PathLocator(localesPath, messagesBasePath);
+  }
+
+  runRule(path, node) {
+    const result = this.pathLocator.call(path);
+
+    if (result.error) {
+      this.context.report({
+        message: result.error,
+        node,
+      });
+    }
+  }
+
+  memberExpression(node) {
+    if (node.object.name !== this.translationFunctionName) {
+      return;
+    }
+
+    const path = node.parent.arguments[0] && node.parent.arguments[0].value;
+
+    if (path) {
+      this.runRule(path, node);
+    }
+  }
+
+  literal(node) {
+    const { parent } = node;
+
+    if (parent && parent.callee && parent.callee.name === this.translationFunctionName) {
+      this.runRule(node.value, node);
+    }
+  }
+
+  call() {
+    return {
+      Literal: this.literal.bind(this),
+      MemberExpression: this.memberExpression.bind(this),
+    };
+  }
+}
+
+const getOptions = (options) => {
+  const { localesPath, messagesBasePath } = options[0] || {};
+
+  let { translationFunctionName } = options[0] || {};
+
+  translationFunctionName = translationFunctionName || 'translate';
+
+  return {
+    localesPath,
+    messagesBasePath,
+    translationFunctionName,
+  };
+};
+
+module.exports = {
+  create: function pathInLocales(context) {
+    const pathInLocalesRunner = new PathInLocalesRunner(context, getOptions(context.options));
+
+    return pathInLocalesRunner.call();
+  },
+  meta: {
+    docs: {
+      category: 'i18n',
+      description: 'Check if all localization strings are defined in locales folder',
+      recommended: true,
+    },
+    schema: [{
+      additionalProperties: false,
+      properties: {
+        localesPath: {
+          items: {
+            type: 'string',
+          },
+          type: 'array',
+        },
+        messagesBasePath: {
+          type: 'string',
+        },
+        translationFunctionName: {
+          type: 'string',
+        },
+      },
+      required: ['localesPath'],
+      type: 'object',
+    }],
+  },
+};

--- a/src/path-locator.js
+++ b/src/path-locator.js
@@ -1,8 +1,9 @@
 const _ = require('lodash');
 
 class PathLocator {
-  constructor(locales) {
+  constructor(locales, messagesBasePath) {
     this.translations = this.getTranslations(locales);
+    this.messagesBasePath = messagesBasePath;
   }
 
   getTranslations(locales) {
@@ -21,9 +22,14 @@ class PathLocator {
 
   checkPathInTranslation(path) {
     const filesWherePathIsNotFound = [];
+    let pathToFind = path;
+
+    if (this.messagesBasePath) {
+      pathToFind = `${this.messagesBasePath}.${path}`;
+    }
 
     this.translations.forEach(({ messages, file }) => {
-      const localizedString = _.get(messages.translation, path);
+      const localizedString = _.get(messages, pathToFind);
 
       if (_.isEmpty(localizedString)) {
         const filename = file.split('/').pop();

--- a/src/path-locator.js
+++ b/src/path-locator.js
@@ -1,19 +1,22 @@
 const _ = require('lodash');
+const fs = require('fs');
 
 class PathLocator {
-  constructor(locales, messagesBasePath) {
-    this.translations = this.getTranslations(locales);
+  constructor(localesPath, messagesBasePath) {
+    this.translations = this.getTranslations(localesPath);
     this.messagesBasePath = messagesBasePath;
   }
 
-  getTranslations(locales) {
+  getTranslations(localesPath = '/locales/') {
     const translations = [];
+    const localesFullPath = `${process.cwd()}/${localesPath}`;
+    const localesFiles = fs.readdirSync(localesFullPath).map(file => file);
 
-    locales.forEach((localeFile) => {
+    localesFiles.forEach((localeFile) => {
       // TODO handle when file is not found
       translations.push({
         file: localeFile,
-        messages: require(localeFile), // eslint-disable-line
+        messages: require(`${localesFullPath}${localeFile}`), // eslint-disable-line
       });
     });
 

--- a/test/fixtures/locales/es-pr.js
+++ b/test/fixtures/locales/es-pr.js
@@ -1,10 +1,8 @@
 const esPr = {
-  translation: {
-    home: {
-      title: 'Home título',
-    },
-    initialKits: 'Kit Inicio',
+  home: {
+    title: 'Home título',
   },
+  initialKits: 'Kit Inicio',
 };
 
 module.exports = esPr;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -14,7 +14,7 @@ ruleTester.run('path-in-locales', rule, {
       ],
       options: [
         {
-          localesPath: ['../test/fixtures/locales/es-pr.js'],
+          localesPath: 'test/fixtures/locales/',
         },
       ],
     },
@@ -24,7 +24,7 @@ ruleTester.run('path-in-locales', rule, {
       code: 'translate("initialKits")',
       options: [
         {
-          localesPath: ['../test/fixtures/locales/es-pr.js'],
+          localesPath: 'test/fixtures/locales/',
         },
       ],
     },
@@ -32,7 +32,7 @@ ruleTester.run('path-in-locales', rule, {
       code: 'translate("home.title")',
       options: [
         {
-          localesPath: ['../test/fixtures/locales/es-pr.js'],
+          localesPath: 'test/fixtures/locales/',
         },
       ],
     },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,9 +1,9 @@
 const { RuleTester } = require('eslint');
-const rule = require('../');
+const rule = require('../src/path-in-locales');
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('i18n-checker', rule, {
+ruleTester.run('path-in-locales', rule, {
   invalid: [
     {
       code: 'translate("notFoundString")',
@@ -38,4 +38,3 @@ ruleTester.run('i18n-checker', rule, {
     },
   ],
 });
-

--- a/test/path-locator.spec.js
+++ b/test/path-locator.spec.js
@@ -6,7 +6,7 @@ describe('pathLocator', () => {
   describe('when path is a string (ex: "title")', () => {
     it('return empty object when path is found in locales files', () => {
       // given
-      const locales = ['../test/fixtures/locales/es-pr.js'];
+      const locales = 'test/fixtures/locales/';
       const path = 'initialKits';
       const pathLocator = new PathLocator(locales);
       // when
@@ -19,7 +19,7 @@ describe('pathLocator', () => {
     it('return error when path is not found in locales files', () => {
       // given
       const filename = 'es-pr.js';
-      const locales = [`../test/fixtures/locales/${filename}`];
+      const locales = 'test/fixtures/locales/';
       const path = 'notFoundString';
       const pathLocator = new PathLocator(locales);
       // when
@@ -34,7 +34,7 @@ describe('pathLocator', () => {
   describe('when path is a path (ex. home.title)', () => {
     it('return empty object when path is found in locales files', () => {
       // given
-      const locales = ['../test/fixtures/locales/es-pr.js'];
+      const locales = 'test/fixtures/locales/';
       const path = 'home.title';
       const pathLocator = new PathLocator(locales);
       // when
@@ -47,7 +47,7 @@ describe('pathLocator', () => {
     it('return error when path is not found in locales files', () => {
       // given
       const filename = 'es-pr.js';
-      const locales = [`../test/fixtures/locales/${filename}`];
+      const locales = 'test/fixtures/locales/';
       const path = 'home.subtitle';
       const pathLocator = new PathLocator(locales);
       // when

--- a/test/path-locator.spec.js
+++ b/test/path-locator.spec.js
@@ -4,7 +4,7 @@ const PathLocator = require('../src/path-locator');
 
 describe('pathLocator', () => {
   describe('when path is a string (ex: "title")', () => {
-    it('return undefined when path is found in locales files', () => {
+    it('return empty object when path is found in locales files', () => {
       // given
       const locales = ['../test/fixtures/locales/es-pr.js'];
       const path = 'initialKits';
@@ -32,7 +32,7 @@ describe('pathLocator', () => {
   });
 
   describe('when path is a path (ex. home.title)', () => {
-    it('return undefined when path is found in locales files', () => {
+    it('return empty object when path is found in locales files', () => {
       // given
       const locales = ['../test/fixtures/locales/es-pr.js'];
       const path = 'home.title';

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,14 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@naturacosmeticos/eslint-config-natura@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@naturacosmeticos/eslint-config-natura/-/eslint-config-natura-1.0.0.tgz#d2cd5648381edc5221a3a59782ccfbcfb775eebe"
+  integrity sha512-GfSHGeZ9RpW4xG1PZGKshPR8bhxBDBBscpAZxaEU1/EO2SZum8f6C+z8uOkBqBoid2cbECIolswCIDR5QUwcLw==
+  dependencies:
+    eslint "^5.7.0"
+    eslint-config-airbnb-base "^13.1.0"
+
 acorn-jsx@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.0.tgz#958584ddb60990c02c97c1bd9d521fce433bb101"
@@ -310,7 +318,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-airbnb-base@^13.0.0:
+eslint-config-airbnb-base@^13.1.0:
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz#b5a1b480b80dfad16433d6c4ad84e6605052c05c"
   integrity sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==
@@ -318,13 +326,6 @@ eslint-config-airbnb-base@^13.0.0:
     eslint-restricted-globals "^0.1.1"
     object.assign "^4.1.0"
     object.entries "^1.0.4"
-
-"eslint-config-natura@https://s3.amazonaws.com/natura-globalsales-artifacts/libs/eslint-config-natura.tar.gz":
-  version "1.0.0"
-  resolved "https://s3.amazonaws.com/natura-globalsales-artifacts/libs/eslint-config-natura.tar.gz#5c5841f14b5756e0f768f4f6ffda66a5aad36767"
-  dependencies:
-    eslint "^5.3.0"
-    eslint-config-airbnb-base "^13.0.0"
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
@@ -381,10 +382,10 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.3.0, eslint@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.7.0.tgz#55c326d6fb2ad45fcbd0ce17c3846f025d1d819c"
-  integrity sha512-zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==
+eslint@^5.7.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.8.0.tgz#91fbf24f6e0471e8fdf681a4d9dd1b2c9f28309b"
+  integrity sha512-Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.5.3"


### PR DESCRIPTION
Also the following changes were made:

- put the rule in the correct eslint format
- refactor `path-in-locales` to improve the understanding
- add messagesBasePath, because some projects have a 'translations' root
key
- `localesPath` is now optional and need to be a string, because the locales files are loaded dynamically (the default is `/locales/`)